### PR TITLE
feat(service): configure port and targetPort sep

### DIFF
--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -4,6 +4,6 @@ description: A wg-easy Wireguard server
 type: application
 icon: https://www.wireguard.com/img/wireguard.svg
 # This is the chart version.
-version: 0.1.14
+version: 0.1.15
 # This is the version number of the application being deployed.
 appVersion: "5"

--- a/charts/wg-easy/templates/service.yaml
+++ b/charts/wg-easy/templates/service.yaml
@@ -21,7 +21,7 @@ spec:
 {{- end }}
   ports:
     - port: {{ .Values.web.service.port }}
-      targetPort: {{ .Values.web.service.port }}
+      targetPort: {{ .Values.web.service.targetPort }}
       protocol: TCP
       name: http
   selector:
@@ -50,7 +50,7 @@ spec:
 {{- end }}
   ports:
     - port: {{ .Values.wireguard.service.port }}
-      targetPort: {{ .Values.wireguard.service.port }}
+      targetPort: {{ .Values.wireguard.service.targetPort }}
       protocol: UDP
       name: wireguard
   selector:

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -21,7 +21,10 @@ web:
 wireguard:
   service:
     type: ClusterIP
+    # Modify this port when wishing to change the service port systems connect to
     port: 51820
+    # This port value should likely not be changed since wg-easy iptables dport is hard coded to 51820
+    targetPort: 51280
     annotations: {}
 
   # Wireguard host is required and used when creating client config


### PR DESCRIPTION
Separately configure port and targetPort for services.

This is because wg-easy hard-codes the iptables rule dport it uses to
51820 https://github.com/WeeJeWel/wg-easy/blob/master/src/config.js#L22

If you modified the port previously, it would not allow things to work
at all, thus port configurability wasn't working as intended.

This change allows you to configure them independently and allow you to
change `port` as intended while allowing you to keep the hard-coded
targetPort.