### PR TITLE
fix: typo in port

### DIFF
--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -4,6 +4,6 @@ description: A wg-easy Wireguard server
 type: application
 icon: https://www.wireguard.com/img/wireguard.svg
 # This is the chart version.
-version: 0.1.15
+version: 0.1.16
 # This is the version number of the application being deployed.
 appVersion: "5"

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -24,7 +24,7 @@ wireguard:
     # Modify this port when wishing to change the service port systems connect to
     port: 51820
     # This port value should likely not be changed since wg-easy iptables dport is hard coded to 51820
-    targetPort: 51280
+    targetPort: 51820
     annotations: {}
 
   # Wireguard host is required and used when creating client config


### PR DESCRIPTION
Sorry. Missed a typo in the values yaml for the port